### PR TITLE
fixade responsivitet produktsida och footer checkout sida

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,4 @@
 html,
-body,
-#root {
-  height: 100%;
-}
-
 body {
   margin: 0;
   height: 100%;
@@ -12,6 +7,12 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
 }
 
 #root * {

--- a/src/routes/CheckoutPage.tsx
+++ b/src/routes/CheckoutPage.tsx
@@ -5,17 +5,24 @@ import Footer from "../components/Footer";
 import Header from "../components/Header";
 import PaymentForm from "../components/PaymentForm";
 
-
 export default function CheckoutPage() {
   return (
     <>
-    <Header type= "white"/>
-    <Box style = {{display: "flex", alignItems:"center", flexDirection: "column"}}>
-      <p>Betalning</p>
-  <PaymentForm/>
-  <p>Leveransmetod</p>
-  <DeliveryForm/>
-  </Box>
-  <Footer/>
-  </>);
+      <Header type="white" />
+      <Box
+        style={{
+          display: "flex",
+          flex: 1,
+          alignItems: "center",
+          flexDirection: "column",
+        }}
+      >
+        <p>Betalning</p>
+        <PaymentForm />
+        <p>Leveransmetod</p>
+        <DeliveryForm />
+      </Box>
+      <Footer />
+    </>
+  );
 }

--- a/src/routes/ProductPage.tsx
+++ b/src/routes/ProductPage.tsx
@@ -56,8 +56,8 @@ export default function ProductPage(props: Props) {
     <>
       {modal && <SmallModal />}
       <Header type={"white"} />
-      <div style={productContainer}>
-        <div style={imageContainer}>
+      <div className="productContainer" style={productContainer}>
+        <div className="productSubContainer" style={imageContainer}>
           <Link to="/">
             <Button
               variant="contained"
@@ -74,7 +74,7 @@ export default function ProductPage(props: Props) {
             alt={product?.name}
           ></img>
         </div>
-        <div style={infoContainer}>
+        <div className="productSubContainer" style={infoContainer}>
           <h2 style={productName}>{product?.name}</h2>
           <p style={productPrice}>{product?.price}&nbsp;kr</p>
           <Button
@@ -95,13 +95,13 @@ export default function ProductPage(props: Props) {
 
 const productContainer: CSSProperties = {
   display: "flex",
-  flexDirection: "row",
-  height: "calc(100% - 7rem)",
+  flex: 1,
+  minHeight: "calc(100vh - 7rem)",
 };
 
 const imageContainer: CSSProperties = {
-  width: "50%",
-  height: "100%",
+  position: "relative",
+  minHeight: "30rem",
 };
 
 const goBackButton: CSSProperties = {
@@ -111,6 +111,7 @@ const goBackButton: CSSProperties = {
 };
 
 const productImage: CSSProperties = {
+  position: "absolute",
   width: "100%",
   height: "100%",
   objectFit: "cover",
@@ -120,7 +121,6 @@ const productImage: CSSProperties = {
 const infoContainer: CSSProperties = {
   display: "flex",
   flexDirection: "column",
-  width: "50%",
   padding: "4rem 3.5rem",
 };
 

--- a/src/styling/style.css
+++ b/src/styling/style.css
@@ -1,3 +1,11 @@
+.productContainer {
+  flex-direction: row;
+}
+
+.productSubContainer {
+  width: 50%;
+}
+
 .footerDiv {
   height: 10.3rem;
 }
@@ -5,7 +13,6 @@
 .footerButton {
   margin: 1.8rem 6.25rem 0 0;
 }
-
 
 /* Product-added modal */
 .smallModal {
@@ -28,9 +35,20 @@
 
 .pInput {
   font-size: 1rem;
-  margin: 2rem 0 0.3rem 3rem
+  margin: 2rem 0 0.3rem 3rem;
 }
 
+/* TABLET SMALL */
+@media only screen and (max-width: 768px) {
+  .productContainer {
+    flex-direction: column;
+  }
+  .productSubContainer {
+    width: 100%;
+  }
+}
+
+/* MOBILE */
 @media only screen and (max-width: 440px) {
   .footerDiv {
     height: 7rem;
@@ -59,10 +77,9 @@
     height: 2rem;
     margin-bottom: 1.7rem;
   }
-  
+
   .pInput {
     font-size: 1rem;
-    margin: 1rem 0 0rem 3rem
+    margin: 1rem 0 0rem 3rem;
   }
-
 }


### PR DESCRIPTION
Gjorde på checkoutsidan att "huvudinnerhållet" flexar och tar alltid upp minst hela fönsterhöjden, det förhindrar att footern ligger mitt i sidan på t.ex. tablet